### PR TITLE
Custom preview templates for DocType items

### DIFF
--- a/Src/Our.Umbraco.Mortar/Web/Controllers/MortarApiController.cs
+++ b/Src/Our.Umbraco.Mortar/Web/Controllers/MortarApiController.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using System.Web.Http;
 using System.Web.Http.ModelBinding;
 using Our.Umbraco.Mortar.Web.Extensions;
+using Umbraco.Core.IO;
 using Umbraco.Core.Models;
 using Umbraco.Core.PropertyEditors;
 using Umbraco.Web.Editors;
@@ -70,6 +71,27 @@ namespace Our.Umbraco.Mortar.Web.Controllers
 			var preValue = Services.DataTypeService.GetPreValuesCollectionByDataTypeId(dtd.Id);
 			var propEditor = PropertyEditorResolver.Current.GetByAlias(dtd.PropertyEditorAlias);
 			return propEditor.PreValueEditor.ConvertDbToEditor(propEditor.DefaultPreValues, preValue);
+		}
+
+		[HttpGet]
+		public object GetDocTypePreview([ModelBinder] Guid guid)
+		{
+			var path = IOHelper.MapPath("~/App_Plugins/Mortar/Views/Previews/{0}.html");
+			var view = string.Empty;
+
+			var file = string.Format(path, guid);
+			if (System.IO.File.Exists(file))
+				view = System.IO.File.ReadAllText(file);
+
+			if (string.IsNullOrWhiteSpace(view))
+			{
+				var alias = Services.ContentTypeService.GetAliasByGuid(guid);
+				var file2 = string.Format(path, alias);
+				if (System.IO.File.Exists(file2))
+					view = System.IO.File.ReadAllText(file2);
+			}
+
+			return new { view = view };
 		}
 	}
 }

--- a/Src/Our.Umbraco.Mortar/Web/UI/App_Plugins/Mortar/Js/mortar.directives.js
+++ b/Src/Our.Umbraco.Mortar/Web/UI/App_Plugins/Mortar/Js/mortar.directives.js
@@ -836,10 +836,20 @@ angular.module("umbraco.directives").directive('mortarEmbedItem',
 
 angular.module("umbraco.directives").directive('mortarDocTypeItem',
     [
+        "$compile",
         "Our.Umbraco.Mortar.Services.docTypeDialogService",
-        function (docTypeDialogService) {
+        "Our.Umbraco.Mortar.Resources.mortarResources",
+        function ($compile, docTypeDialogService, mortarResources) {
 
             var link = function ($scope, element, attrs, ctrl) {
+
+                mortarResources.getDocTypePreview($scope.model.docType).then(function (data) {
+                    if (data.view != "") {
+                        var label = element.find(".mortar-item__label");
+                        label.html(data.view).show();
+                        $compile(label.contents())($scope);
+                    }
+                });
 
                 $scope.configure = function () {
                     docTypeDialogService.open({
@@ -890,7 +900,7 @@ angular.module("umbraco.directives").directive('mortarDocTypeItem',
     ]);
 
 angular.module("umbraco.directives").directive('jsonTextarea', function () {
-    return { 
+    return {
         restrict: 'A',
         require: 'ngModel',
         link: function (scope, element, attr, ctrl) {

--- a/Src/Our.Umbraco.Mortar/Web/UI/App_Plugins/Mortar/Js/mortar.resources.js
+++ b/Src/Our.Umbraco.Mortar/Web/UI/App_Plugins/Mortar/Js/mortar.resources.js
@@ -27,6 +27,13 @@ angular.module('umbraco.resources').factory('Our.Umbraco.Mortar.Resources.mortar
                     $http.get(url),
                     'Failed to retrieve datatypes'
                 );
-            }
+            },
+            getDocTypePreview: function (guid) {
+                var url = "/umbraco/backoffice/MortarApi/MortarApi/GetDocTypePreview?guid=" + guid;
+                return umbRequestHelper.resourcePromise(
+                    $http.get(url),
+                    'Failed to retrieve doctype preview by guid'
+                );
+            },
         };
     });


### PR DESCRIPTION
Added a feature to use a custom (Angular) template for DocType item previews.

It introduces an extra HTTP request, but offers a potentially richer UI display for the content-editor.